### PR TITLE
You have to init the store somewhere for the example to work.

### DIFF
--- a/manuscript/06_react_and_flux.md
+++ b/manuscript/06_react_and_flux.md
@@ -395,7 +395,8 @@ export default persist(
   connect(App, NoteStore),
   storage,
   noteStorageName,
-  () => NoteStore.getState()
+  () => NoteStore.getState(),
+  NoteActions.init(storage.get(noteStorageName))
 );
 ```
 


### PR DESCRIPTION
It is better to pass `NoteActions` or `NoteActions.init` trigger `init` in `constructor` method, but then it would require more changes down the page.

This is not good, but if I put Store init in `App#constructor` it blows up because of typecheck:

```
Uncaught TypeError: Expected an instance of array got undefined, context: arguments / [{notes: Array<any>;}] / 0 / {notes: Array<any>;} / notes / Array<any>
```
